### PR TITLE
[PS-6494] Adding in preventative fix for this._sceneRefs crash

### DIFF
--- a/src/Navigator.js
+++ b/src/Navigator.js
@@ -725,7 +725,8 @@ var Navigator = createReactClass({
 
   _clearTransformations: function(sceneIndex) {
     const defaultStyle = flattenStyle([DEFAULT_SCENE_STYLE]);
-    this._sceneRefs[sceneIndex].setNativeProps({ style: defaultStyle });
+    this._sceneRefs[sceneIndex] &&
+      this._sceneRefs[sceneIndex].setNativeProps({ style: defaultStyle });
   },
 
   _onAnimationStart: function() {


### PR DESCRIPTION
Adding the preventative found in other parts of the code to a method that was missing it per the issue found here:

https://github.com/facebookarchive/react-native-custom-components/issues/33

This should prevent the this._sceneRefs crash that happens with the Android back button.